### PR TITLE
Fix random build failures on mac

### DIFF
--- a/plugins/logdelete/CMakeLists.txt
+++ b/plugins/logdelete/CMakeLists.txt
@@ -30,3 +30,5 @@ add_plugin(logdelete STATIC logdelete.c)
 if (COMDB2_BBCMAKE)
   comdb2_bb_target(logdelete)
 endif()
+
+add_dependencies(logdelete proto)

--- a/plugins/repopnewlrl/CMakeLists.txt
+++ b/plugins/repopnewlrl/CMakeLists.txt
@@ -29,3 +29,5 @@ add_plugin(repopnewlrl STATIC repopnewlrl.c)
 if (COMDB2_BBCMAKE)
   comdb2_bb_target(repopnewlrl)
 endif()
+
+add_dependencies(repopnewlrl proto)


### PR DESCRIPTION
In file included from $...comdb2/plugins/repopnewlrl/repopnewlrl.c:17:
In file included from $...code/comdb2/db/comdb2.h:75:
In file included from $...comdb2/db/sqlinterfaces.h:36:
$...comdb2/bdb/bdb_api.h:45:10: fatal error: 'sqlresponse.pb-c.h' file not found
#include <sqlresponse.pb-c.h>